### PR TITLE
feat : Notion API 연동

### DIFF
--- a/auto-planner-backend/package-lock.json
+++ b/auto-planner-backend/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.1.6",
+        "@notionhq/client": "^2.3.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
@@ -2789,6 +2790,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@notionhq/client": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.3.0.tgz",
+      "integrity": "sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-fetch": "^2.5.10",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@nuxt/opencollective": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
@@ -3470,6 +3484,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/qs": {
@@ -4857,7 +4881,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/b4a": {
@@ -5600,7 +5623,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -5926,7 +5948,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -6135,7 +6156,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6914,7 +6934,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
       "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -6940,7 +6959,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6950,7 +6968,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -7299,7 +7316,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -9130,6 +9146,26 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-int64": {
@@ -11184,6 +11220,12 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -11669,6 +11711,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/webpack": {
       "version": "5.99.7",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.7.tgz",
@@ -11867,6 +11915,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/auto-planner-backend/package.json
+++ b/auto-planner-backend/package.json
@@ -26,6 +26,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.1.6",
+    "@notionhq/client": "^2.3.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",

--- a/auto-planner-backend/src/notion/notion.module.ts
+++ b/auto-planner-backend/src/notion/notion.module.ts
@@ -4,6 +4,7 @@ import { NotionService } from './notion.service';
 
 @Module({
   controllers: [NotionController],
-  providers: [NotionService]
+  providers: [NotionService],
+  exports: [NotionService],
 })
 export class NotionModule {}

--- a/auto-planner-backend/src/notion/notion.service.ts
+++ b/auto-planner-backend/src/notion/notion.service.ts
@@ -1,13 +1,51 @@
 import { Injectable } from '@nestjs/common';
+import { Client } from '@notionhq/client';
 import { SyncToNotionDto } from './dto/sync-to-notion.dto';
 
 @Injectable()
 export class NotionService {
-  syncToNotion(dto: SyncToNotionDto) {
-    // 실제 Notion API 연동 대신 모의 응답
-    return {
-      message: 'Notion에 일정이 전송되었습니다 (Mock)',
-      syncedData: dto
-    };
+  private notion = new Client({
+    auth: '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', // 실제 코드에서는 .env 사용 권장
+  });
+
+  private databaseId = '1ea4fa76f8688090ae04fed52a6e3ca7';
+
+  async addPlanEntry(data: {
+    userId: string;
+    subject: string;
+    date: string;
+    content: string;
+  }) {
+    return await this.notion.pages.create({
+      parent: { database_id: this.databaseId },
+      properties: {
+        Subject: {
+          title: [{ text: { content: data.subject } }],
+        },
+        'User ID': {
+          rich_text: [{ text: { content: data.userId } }],
+        },
+        Date: {
+          date: { start: data.date },
+        },
+        Content: {
+          rich_text: [{ text: { content: data.content } }],
+        },
+      },
+    });
+  }
+
+  async syncToNotion(dto: SyncToNotionDto) {
+    for (const entry of dto.dailyPlan) {
+      const [date, content] = entry.split(':').map((v) => v.trim());
+      await this.addPlanEntry({
+        userId: dto.userId,
+        subject: dto.subject,
+        date: `2025-${date.replace('/', '-')}`,
+        content,
+      });
+    }
+
+    return { message: '노션 연동 완료', count: dto.dailyPlan.length };
   }
 }

--- a/auto-planner-backend/src/planner/planner.module.ts
+++ b/auto-planner-backend/src/planner/planner.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { PlannerController } from './planner.controller';
 import { PlannerService } from './planner.service';
-
+import { NotionModule } from 'src/notion/notion.module';
 @Module({
+  imports: [NotionModule],
   controllers: [PlannerController],
   providers: [PlannerService]
 })

--- a/auto-planner-backend/src/user/dto/create-user.dto.ts
+++ b/auto-planner-backend/src/user/dto/create-user.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateUserDto {
-  @ApiProperty({ example: 'user123' })
+  @ApiProperty({ example: '202255179' })
   userId: string;
 
-  @ApiProperty({ example: 'securepassword' })
+  @ApiProperty({ example: 'yuhuijeong' })
   password: string;
 
-  @ApiProperty({ example: '집중 잘 되는 아침형' })
+  @ApiProperty({ example: '새벽형' })
   studyPreference: string;
 }


### PR DESCRIPTION
- 인증 기능
JWT 기반 로그인 기능 구현 (/auth/login)
JwtStrategy 및 JwtAuthGuard 설정
Swagger UI에서 Bearer Token으로 인증 테스트 가능하도록 설정

- AI 플래너 기능 확장
/planner/:id/confirm 요청 시 사용자의 학습 계획을 Notion에 자동 연동
계획 항목을 하루 단위로 분할하여 Notion Database에 한 줄씩 기록

-Notion 연동
Notion API 통합 설정 완료 (@notionhq/client)
날짜 포맷 오류 수정 (YYYY-MM-DD → ISO 8601 형식 자동 변환)
팀 워크스페이스 내 공유 Database에 정상 연동 확인